### PR TITLE
File languages

### DIFF
--- a/src/components/FileDownload/FileDownloadImpl.jsx
+++ b/src/components/FileDownload/FileDownloadImpl.jsx
@@ -3,17 +3,67 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import mime from 'mime';
 
+import { useI18nContext } from '@eci/context/I18n';
 import formatBytes from '@eci/utils/formatBytes';
 import { useDocumentApi, getResource } from '@eci/utils/useDocumentApi';
+import getLanguages from '@eci/utils/getLanguages';
 
+import Link from '../Link/LinkGatsby';
 import ErrorMessage from '../ErrorMessage';
 import { FileDownload } from './FileDownload';
 
 const FileDownloadImpl = ({ file }) => {
   if (!file || Object.keys(file).length === 0) return '';
-  if (!file.id) return '';
+  if (!file.id && (!file.languages || file.languages.length === 0)) return '';
 
+  const { location } = useI18nContext();
   const { t } = useTranslation();
+  const languageTranslations = getLanguages(t);
+
+  const { languages: otherLanguages, language: fileLanguage } = file;
+
+  const languageTranslation = languageTranslations.find(
+    l => l.value === fileLanguage
+  );
+  const language = languageTranslation ? languageTranslation.label : '';
+
+  const languages = otherLanguages
+    ? otherLanguages.map(language => {
+        let urlPath = '';
+        let pathParts = [];
+
+        const translation = languageTranslations.find(
+          l => l.value === language
+        );
+
+        pathParts = location.pathname.split('/').filter(p => p);
+
+        pathParts.shift();
+
+        urlPath = pathParts.join('/');
+        urlPath = `/${translation.value}/${urlPath}/`;
+
+        if (location.hash) {
+          urlPath += location.hash;
+        }
+
+        // Link attributes for the component's spread.
+        return { label: translation.label, href: urlPath };
+      })
+    : [];
+
+  if (!file.id && languages.length) {
+    return (
+      <p className="ecl-u-type-paragraph">
+        {t('Other languages available')}:{' '}
+        {languages.map((attr, key) => [
+          key > 0 && ', ',
+          <Link {...attr} key={key} />,
+        ])}
+      </p>
+    );
+  }
+
   const { error } = useDocumentApi(file.id);
   const resource = getResource(file.id);
 
@@ -37,7 +87,7 @@ const FileDownloadImpl = ({ file }) => {
   return (
     <FileDownload
       title={title}
-      language=""
+      language={language}
       meta={meta}
       download={{ label: t('Download'), href: resource }}
       icon={{ shape: 'general--copy', size: '2xl' }}
@@ -48,6 +98,8 @@ const FileDownloadImpl = ({ file }) => {
 FileDownloadImpl.propTypes = {
   file: PropTypes.shape({
     name: PropTypes.string,
+    language: PropTypes.string,
+    languages: PropTypes.arrayOf(PropTypes.string),
     mimeType: PropTypes.string,
     id: PropTypes.number,
     size: PropTypes.number,

--- a/src/components/FileDownload/FileDownloadImpl.jsx
+++ b/src/components/FileDownload/FileDownloadImpl.jsx
@@ -14,13 +14,14 @@ import { FileDownload } from './FileDownload';
 
 const FileDownloadImpl = ({ file }) => {
   if (!file || Object.keys(file).length === 0) return '';
-  if (!file.id && (!file.languages || file.languages.length === 0)) return '';
+  if (!file.id && (!file.otherLanguages || file.otherLanguages.length === 0))
+    return '';
 
   const { location } = useI18nContext();
   const { t } = useTranslation();
   const languageTranslations = getLanguages(t);
 
-  const { languages: otherLanguages, language: fileLanguage } = file;
+  const { otherLanguages, language: fileLanguage } = file;
 
   const languageTranslation = languageTranslations.find(
     l => l.value === fileLanguage

--- a/src/components/FileDownload/FileDownloadImpl.jsx
+++ b/src/components/FileDownload/FileDownloadImpl.jsx
@@ -19,23 +19,19 @@ const FileDownloadImpl = ({ file }) => {
 
   const { location } = useI18nContext();
   const { t } = useTranslation();
-  const languageTranslations = getLanguages(t);
+  const langsT = getLanguages(t);
 
   const { otherLanguages, language: fileLanguage } = file;
 
-  const languageTranslation = languageTranslations.find(
-    l => l.value === fileLanguage
-  );
-  const language = languageTranslation ? languageTranslation.label : '';
+  const langT = langsT.find(l => l.value === fileLanguage);
+  const language = langT ? langT.label : '';
 
   const languages = otherLanguages
     ? otherLanguages.map(language => {
         let urlPath = '';
         let pathParts = [];
 
-        const translation = languageTranslations.find(
-          l => l.value === language
-        );
+        const translation = langsT.find(l => l.value === language);
 
         pathParts = location.pathname.split('/').filter(p => p);
 
@@ -100,7 +96,7 @@ FileDownloadImpl.propTypes = {
   file: PropTypes.shape({
     name: PropTypes.string,
     language: PropTypes.string,
-    languages: PropTypes.arrayOf(PropTypes.string),
+    otherLanguages: PropTypes.arrayOf(PropTypes.string),
     mimeType: PropTypes.string,
     id: PropTypes.number,
     size: PropTypes.number,

--- a/src/components/FileDownload/FileDownloadImpl.test.js
+++ b/src/components/FileDownload/FileDownloadImpl.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import * as useDocumentApi from '@eci/utils/useDocumentApi';
+import * as I18nContext from '@eci/context/I18n';
 import FileDownloadImpl from './FileDownloadImpl';
 
 describe('FileDownloadImpl', () => {
@@ -16,12 +17,67 @@ describe('FileDownloadImpl', () => {
   });
 
   it('renders correctly provided an input', () => {
+    jest.spyOn(I18nContext, 'useI18nContext').mockImplementation(() => ({
+      locale: 'en',
+      location: {
+        href: 'http://localhost:8000/en/initiatives/#1',
+        pathname: '/en/initiatives/',
+        hash: '#1',
+      },
+    }));
+
     const props = {
       file: {
         name: 'test',
         mimeType: 'text/plain',
         id: 16806,
         size: 10,
+        languages: [],
+      },
+    };
+
+    const { container } = render(<FileDownloadImpl {...props} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders language label when provided', () => {
+    jest.spyOn(I18nContext, 'useI18nContext').mockImplementation(() => ({
+      locale: 'en',
+      location: {
+        href: 'http://localhost:8000/en/initiatives/#1',
+        pathname: '/en/initiatives/',
+        hash: '#1',
+      },
+    }));
+
+    const props = {
+      file: {
+        name: 'test',
+        mimeType: 'text/plain',
+        id: 16806,
+        size: 10,
+        language: 'en',
+        languages: [],
+      },
+    };
+
+    const { container } = render(<FileDownloadImpl {...props} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('can render a message for alternative language versions when a file is not available', () => {
+    jest.spyOn(I18nContext, 'useI18nContext').mockImplementation(() => ({
+      locale: 'en',
+      location: {
+        href: 'http://localhost:8000/en/initiatives/#1',
+        pathname: '/en/initiatives/',
+        hash: '#1',
+      },
+    }));
+
+    const props = {
+      file: {
+        languages: ['bg', 'cs'],
       },
     };
 
@@ -42,6 +98,7 @@ describe('FileDownloadImpl', () => {
         mimeType: 'text/plain',
         id: 16806,
         size: 10,
+        languages: [],
       },
     };
 

--- a/src/components/FileDownload/FileDownloadImpl.test.js
+++ b/src/components/FileDownload/FileDownloadImpl.test.js
@@ -32,7 +32,6 @@ describe('FileDownloadImpl', () => {
         mimeType: 'text/plain',
         id: 16806,
         size: 10,
-        languages: [],
       },
     };
 
@@ -52,12 +51,11 @@ describe('FileDownloadImpl', () => {
 
     const props = {
       file: {
+        language: 'en',
         name: 'test',
         mimeType: 'text/plain',
         id: 16806,
         size: 10,
-        language: 'en',
-        languages: [],
       },
     };
 
@@ -77,7 +75,7 @@ describe('FileDownloadImpl', () => {
 
     const props = {
       file: {
-        languages: ['bg', 'cs'],
+        otherLanguages: ['bg', 'cs'],
       },
     };
 
@@ -98,7 +96,6 @@ describe('FileDownloadImpl', () => {
         mimeType: 'text/plain',
         id: 16806,
         size: 10,
-        languages: [],
       },
     };
 

--- a/src/components/FileDownload/__snapshots__/FileDownloadImpl.test.js.snap
+++ b/src/components/FileDownload/__snapshots__/FileDownloadImpl.test.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FileDownloadImpl can render a message for alternative language versions when a file is not available 1`] = `
+<div>
+  <p
+    class="ecl-u-type-paragraph"
+  >
+    Other languages available
+    :
+     
+    <a
+      class="ecl-link"
+      href="/bg/initiatives/#1"
+    >
+      Bulgarian
+    </a>
+    , 
+    <a
+      class="ecl-link"
+      href="/cs/initiatives/#1"
+    >
+      Czech
+    </a>
+  </p>
+</div>
+`;
+
 exports[`FileDownloadImpl does not render anything on missing id 1`] = `
 <div>
   
@@ -107,6 +132,73 @@ exports[`FileDownloadImpl renders correctly provided an input 1`] = `
         <div
           class="ecl-file__language"
         />
+        <div
+          class="ecl-file__meta"
+        >
+          10 Bytes - TXT
+        </div>
+      </div>
+      <a
+        class="ecl-file__download ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after"
+        download=""
+        href="undefined/register/document/16806"
+      >
+        <span
+          class="ecl-link__label"
+        >
+          Download
+        </span>
+         
+        <svg
+          aria-hidden="true"
+          class="ecl-link__icon ecl-icon ecl-icon--fluid"
+          focusable="false"
+        >
+          
+          
+          <use
+            xlink:href="file#ui--download"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FileDownloadImpl renders language label when provided 1`] = `
+<div>
+  <div
+    class="ecl-file"
+    data-ecl-file="true"
+  >
+    <div
+      class="ecl-file__container"
+    >
+      <svg
+        aria-hidden="true"
+        class="ecl-file__icon ecl-icon ecl-icon--2xl"
+        focusable="false"
+      >
+        
+        
+        <use
+          xlink:href="file#general--copy"
+        />
+      </svg>
+      <div
+        class="ecl-file__info"
+      >
+        <div
+          class="ecl-file__title"
+        >
+          test
+        </div>
+        <div
+          class="ecl-file__language"
+        >
+          English
+        </div>
         <div
           class="ecl-file__meta"
         >

--- a/src/components/Funding/Funding.test.js
+++ b/src/components/Funding/Funding.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import * as I18nContext from '@eci/context/I18n';
+
 import Funding from './Funding';
 
 describe('Funding', () => {
@@ -43,6 +45,15 @@ describe('Funding', () => {
   });
 
   it('Renders a file section when document property is present', () => {
+    jest.spyOn(I18nContext, 'useI18nContext').mockImplementation(() => ({
+      locale: 'en',
+      location: {
+        href: 'http://localhost:8000/en/initiatives/#1',
+        pathname: '/en/initiatives/',
+        hash: '#1',
+      },
+    }));
+
     const props = {
       funding: {
         document: {
@@ -50,6 +61,7 @@ describe('Funding', () => {
           name: 'DummyMemberDoc1.txt',
           mimeType: 'text/plain',
           size: 10,
+          languages: [],
         },
       },
     };

--- a/src/components/Funding/Funding.test.js
+++ b/src/components/Funding/Funding.test.js
@@ -61,7 +61,6 @@ describe('Funding', () => {
           name: 'DummyMemberDoc1.txt',
           mimeType: 'text/plain',
           size: 10,
-          languages: [],
         },
       },
     };

--- a/src/components/Section/Section.test.js
+++ b/src/components/Section/Section.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import * as I18nContext from '@eci/context/I18n';
+
 import FileDownload from '../FileDownload';
 import Section from './Section';
 
@@ -16,6 +18,15 @@ describe('Section', () => {
   });
 
   it('can render children even if no title is provided', () => {
+    jest.spyOn(I18nContext, 'useI18nContext').mockImplementation(() => ({
+      locale: 'en',
+      location: {
+        href: 'http://localhost:8000/en/initiatives/#1',
+        pathname: '/en/initiatives/',
+        hash: '#1',
+      },
+    }));
+
     const tree = renderer
       .create(
         <Section>
@@ -25,6 +36,7 @@ describe('Section', () => {
               mimeType: 'text/plain',
               id: 16806,
               size: 10,
+              languages: [],
             }}
           />
         </Section>

--- a/src/components/Section/Section.test.js
+++ b/src/components/Section/Section.test.js
@@ -36,7 +36,6 @@ describe('Section', () => {
               mimeType: 'text/plain',
               id: 16806,
               size: 10,
-              languages: [],
             }}
           />
         </Section>

--- a/src/pages/initiative.jsx
+++ b/src/pages/initiative.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import useDetailsApi from '@eci/utils/useDetailsApi';
 import extractInitiativesDetails from '@eci/utils/extractInitiativesDetails';
+import shouldDisplayFile from '@eci/utils/shouldDisplayFile';
 
 import ErrorMessage from '../components/ErrorMessage';
 import FileDownload from '../components/FileDownload';
@@ -177,12 +178,12 @@ const Initiative = ({ location, pageContext: { locale } }) => {
                   />
                 </Section>
               )}
-              {Object.keys(additionalDocument).length !== 0 && (
+              {shouldDisplayFile(additionalDocument) && (
                 <Section title={t('Additional information')}>
                   <FileDownload file={additionalDocument} />
                 </Section>
               )}
-              {Object.keys(draftLegal).length !== 0 && (
+              {shouldDisplayFile(draftLegal) && (
                 <Section title={t('Draft legal act')}>
                   <FileDownload file={draftLegal} />
                 </Section>

--- a/src/utils/extractInitiativesDetails.js
+++ b/src/utils/extractInitiativesDetails.js
@@ -53,6 +53,8 @@ const extractInitiativesDetails = ({ details, locale }) => {
       ? linguisticVersion.title
       : '...';
 
+  const language = linguisticVersion && linguisticVersion.languageCode;
+
   const draftLegal =
     linguisticVersion && linguisticVersion.draftLegal
       ? linguisticVersion.draftLegal
@@ -60,8 +62,23 @@ const extractInitiativesDetails = ({ details, locale }) => {
 
   const additionalDocument =
     linguisticVersion && linguisticVersion.additionalDocument
-      ? linguisticVersion.additionalDocument
+      ? {
+          ...linguisticVersion.additionalDocument,
+          language: language.toLowerCase(),
+        }
       : {};
+
+  if (!additionalDocument.language && !additionalDocument.id) {
+    const languages = [];
+
+    linguisticVersions.forEach(version => {
+      if (version.additionalDocument) {
+        languages.push(version.languageCode.toLowerCase());
+      }
+    });
+
+    additionalDocument.languages = languages;
+  }
 
   const annexText =
     linguisticVersion && linguisticVersion.annexText

--- a/src/utils/shouldDisplayFile.js
+++ b/src/utils/shouldDisplayFile.js
@@ -1,0 +1,18 @@
+/**
+ * Checks whether a given file has enough data to be displayed.
+ * @param {Object} file
+ * @param {Number} file.id
+ * @param {Array} file.otherLanguages
+ * @returns {Boolean}
+ */
+const shouldDisplayFile = file => {
+  if (!file || typeof file !== 'object') return false;
+  if (Array.isArray(file)) return false;
+
+  if (file.id) return true;
+  if (file.otherLanguages && Array.isArray(file.otherLanguages)) return true;
+
+  return false;
+};
+
+export default shouldDisplayFile;

--- a/src/utils/tests/__snapshots__/extractInitiativesDetails.test.js.snap
+++ b/src/utils/tests/__snapshots__/extractInitiativesDetails.test.js.snap
@@ -4,6 +4,7 @@ exports[`extractInitiativesDetails utlity ongoing initiative case: English local
 Object {
   "additionalDocument": Object {
     "id": 17003,
+    "language": "en",
     "mimeType": "text/plain",
     "name": "testAnnex5.txt",
     "size": 19,

--- a/src/utils/tests/__snapshots__/extractInitiativesDetails.test.js.snap
+++ b/src/utils/tests/__snapshots__/extractInitiativesDetails.test.js.snap
@@ -18,6 +18,7 @@ Object {
   "decisionUrl": "http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:ABACECD323&from=EN",
   "draftLegal": Object {
     "id": 16806,
+    "language": "en",
     "mimeType": "text/plain",
     "name": "DummyMemberDoc1.txt",
     "size": 10,

--- a/src/utils/tests/extractInitiativesDetails.test.js
+++ b/src/utils/tests/extractInitiativesDetails.test.js
@@ -10,4 +10,21 @@ describe('extractInitiativesDetails utlity', () => {
     });
     expect(result).toMatchSnapshot();
   });
+
+  it('Annex field: contains language from linguisticVersion', () => {
+    const result = extractInitiativesDetails({
+      details: ongoingInitiative,
+      locale: 'en',
+    });
+    expect(result.additionalDocument.language).toBe('en');
+  });
+
+  it('Annex field: contains data about other languages', () => {
+    const result = extractInitiativesDetails({
+      details: ongoingInitiative,
+      locale: 'fr',
+    });
+    expect(result.additionalDocument.language).toBe(undefined);
+    expect(result.additionalDocument.languages).toEqual(['en', 'es', 'cs']);
+  });
 });

--- a/src/utils/tests/extractInitiativesDetails.test.js
+++ b/src/utils/tests/extractInitiativesDetails.test.js
@@ -25,6 +25,10 @@ describe('extractInitiativesDetails utlity', () => {
       locale: 'fr',
     });
     expect(result.additionalDocument.language).toBe(undefined);
-    expect(result.additionalDocument.languages).toEqual(['en', 'es', 'cs']);
+    expect(result.additionalDocument.otherLanguages).toEqual([
+      'en',
+      'es',
+      'cs',
+    ]);
   });
 });

--- a/src/utils/tests/shouldDisplayFile.test.js
+++ b/src/utils/tests/shouldDisplayFile.test.js
@@ -1,0 +1,46 @@
+import shouldDisplayFile from '../shouldDisplayFile';
+
+describe('shouldDisplayFile utlity', () => {
+  it('missing input is not acceptable', () => {
+    const result = shouldDisplayFile();
+    expect(result).toBe(false);
+  });
+
+  it('string input is not acceptable', () => {
+    const result = shouldDisplayFile('foo');
+    expect(result).toBe(false);
+  });
+
+  it('number input is not acceptable', () => {
+    const result = shouldDisplayFile(1);
+    expect(result).toBe(false);
+  });
+
+  it('boolean input is not acceptable', () => {
+    const result = shouldDisplayFile(true);
+    expect(result).toBe(false);
+  });
+
+  it('array input is not acceptable', () => {
+    const result = shouldDisplayFile(['file']);
+    expect(result).toBe(false);
+  });
+
+  it('an object/map of languages is not acceptable', () => {
+    const file = { otherLanguages: { something: 'en' } };
+    const result = shouldDisplayFile(file);
+    expect(result).toBe(false);
+  });
+
+  it('object with an id is acceptable', () => {
+    const file = { id: 1 };
+    const result = shouldDisplayFile(file);
+    expect(result).toBe(true);
+  });
+
+  it('an array of languages is acceptable', () => {
+    const file = { otherLanguages: ['en'] };
+    const result = shouldDisplayFile(file);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
Initiatives API provides several language versions for content. A file always have 1 language, but when the content language does not have a file in the same language, a message should be displayed that there are alternatives for the content of the file in a given set of languages.

Changes:
- File information extraction logic,adds `otherLanguages` which is different than ECL's FileDownload `translation.items` because the 2 are different things.
- File implementation component updated: now displays file language together with existing file data. It also displays a list of alternatives, i.e. list of languages in which the given file has information

Notes:
Logic to display fallback content language is still valid regardless of the files' languages. This means if a page is available in en and bg, but not in fr, fr will display files of en (potentially default/original) and if en/original/default does not have a file in en, but in bg, then bg will be suggested ...
